### PR TITLE
Fix for impossibility to remove an existing keyword from a bookmark

### DIFF
--- a/common/bookmarks/editBookmarkOverlay.js
+++ b/common/bookmarks/editBookmarkOverlay.js
@@ -595,8 +595,9 @@ var gEditItemOverlay = {
 
   onKeywordFieldBlur: function EIO_onKeywordFieldBlur() {
     var keyword = this._element("keywordField").value;
-    if (keyword != PlacesUtils.bookmarks.getKeywordForBookmark(this._itemId)) {
-      var txn = new PlacesEditBookmarkKeywordTransaction(this._itemId, keyword);
+    var oldKeyword = PlacesUtils.bookmarks.getKeywordForBookmark(this._itemId);
+    if (keyword != oldKeyword) {
+      var txn = new PlacesEditBookmarkKeywordTransaction(this._itemId, keyword, null, oldKeyword);
       PlacesUtils.transactionManager.doTransaction(txn);
     }
   },


### PR DESCRIPTION
There is a long-living (inherited from the Seamonkey) bug in the Bookmark manager: any keyword, once added to a bookmark, can not be neither edited, nor removed from that bookmark.

Attempts to remove it result in no changes.
Attempts to edit it are even worse: after every edition a new keyword gets assigned to the bookmark, but all previous ones persist in the places.sqlite, and all they remain assigned to the bookmark!

This PR addresses the issue.